### PR TITLE
Creates GraphQL Schema for Data

### DIFF
--- a/infoset/api/schema_data.py
+++ b/infoset/api/schema_data.py
@@ -17,9 +17,6 @@ class Data(SQLAlchemyObjectType, DataAttribute):
         interfaces = (relay.Node, )
 
 
-
-
-
 class DataInput(graphene.InputObjectType, DataAttribute):
     """Arguments to create data."""
     pass
@@ -35,8 +32,6 @@ class CreateData(graphene.Mutation):
 
     def mutate(self, info, input):
         data = graphene_utils.input_to_dictionary(input)
-        
-
         _data = DataModel(**data)
         db_session.add(_data)
         db_session.commit()
@@ -55,11 +50,9 @@ class UpdateData(graphene.Mutation):
 
     def mutate(self, info, input):
         data = graphene_utils.input_to_dictionary(input)
-
         _data = db_session.query(DataModel).filter_by(id=data['id'])
         _data.update(data)
         db_session.commit()
         _data = db_session.query(DataModel).filter_by(id=data['id']).first()
 
         return UpdateData(_data=_data)
-

--- a/infoset/api/schema_data.py
+++ b/infoset/api/schema_data.py
@@ -41,6 +41,7 @@ class CreateData(graphene.Mutation):
 class UpdateDataInput(graphene.InputObjectType, DataAttribute):
 
     id = graphene.ID(required=True, description="Unique identifier of the Data")
+    
 
 class UpdateData(graphene.Mutation):
     _data = graphene.Field(lambda: Data, description="Data updated by this mutation.")

--- a/infoset/api/schema_data.py
+++ b/infoset/api/schema_data.py
@@ -1,0 +1,65 @@
+import graphene
+from graphene import relay
+from graphene_sqlalchemy import SQLAlchemyObjectType, SQLAlchemyConnectionField
+from infoset.api import graphene_utils
+from infoset.db.db_orm import db_session, Data as DataModel
+from datetime import datetime
+
+class DataAttribute:
+    idx_datapoint = graphene.ID(description="")
+    timestamp = graphene.Float(description="")
+    value = graphene.Int(description="")
+
+
+class Data(SQLAlchemyObjectType, DataAttribute):
+    class Meta:
+        model = DataModel
+        interfaces = (relay.Node, )
+
+
+
+
+
+class DataInput(graphene.InputObjectType, DataAttribute):
+    """Arguments to create data."""
+    pass
+
+
+class CreateData(graphene.Mutation):
+    """Mutation to create a data."""
+    _data = graphene.Field(
+        lambda: Data, description="Data created by this mutation.")
+
+    class Arguments:
+        input = DataInput(required=True)
+
+    def mutate(self, info, input):
+        data = graphene_utils.input_to_dictionary(input)
+        
+
+        _data = DataModel(**data)
+        db_session.add(_data)
+        db_session.commit()
+
+        return CreateData(_data=_data)
+
+class UpdateDataInput(graphene.InputObjectType, DataAttribute):
+
+    id = graphene.ID(required=True, description="Unique identifier of the Data")
+
+class UpdateData(graphene.Mutation):
+    _data = graphene.Field(lambda: Data, description="Data updated by this mutation.")
+
+    class Arguments:
+        input = UpdateDataInput(required=True)
+
+    def mutate(self, info, input):
+        data = graphene_utils.input_to_dictionary(input)
+
+        _data = db_session.query(DataModel).filter_by(id=data['id'])
+        _data.update(data)
+        db_session.commit()
+        _data = db_session.query(DataModel).filter_by(id=data['id']).first()
+
+        return UpdateData(_data=_data)
+


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/PalisadoesFoundation/garnet/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | yes
| Deprecations?            |  no
| Tests Added/Pass?        | no/yes
| Fixed Tickets            | #155.3
| License                  | MIT
| Doc PR                   |no <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | no

<!-- Describe your changes below in as much detail as possible -->
The graphql schema for Data was added to Infoset. Tests for each query and mutation were carried out manually through GraphiQL. 