### PR TITLE
Creates GraphQL Schema for DeviceAgent

### DIFF
--- a/infoset/api/schema_deviceagent.py
+++ b/infoset/api/schema_deviceagent.py
@@ -5,21 +5,14 @@ from infoset.api import graphene_utils
 from infoset.db.db_orm import db_session, DeviceAgent as DeviceAgentModel
 from datetime import datetime
 
-class DeviceAgentAttribute:
-    
+class DeviceAgentAttribute:   
 
     idx_deviceagent =  graphene.ID(description="")
-
-    idx_device = graphene.Float(description="")
-    
+    idx_device = graphene.Float(description="")    
     idx_agent = graphene.Float(description="")
-
     last_timestamp = graphene.Float(description="")
-
     enabled = graphene.Float(description="")
-
     ts_modified = graphene.DateTime(description="")
-
     ts_created = graphene.DateTime(description="")
 
 
@@ -27,9 +20,6 @@ class DeviceAgent(SQLAlchemyObjectType, DeviceAgentAttribute):
     class Meta:
         model = DeviceAgentModel
         interfaces = (relay.Node, )
-
-
-
 
 
 class DeviceAgentInput(graphene.InputObjectType, DeviceAgentAttribute):
@@ -55,10 +45,12 @@ class CreateDeviceAgent(graphene.Mutation):
         db_session.commit()
 
         return CreateDeviceAgent(_deviceagent=_deviceagent)
+    
 
 class UpdateDeviceAgentInput(graphene.InputObjectType, DeviceAgentAttribute):
 
     _deviceagent = graphene.ID(required=True, description="Unique identifier of the DeviceAgent")
+    
 
 class UpdateDeviceAgent(graphene.Mutation):
     _deviceagent = graphene.Field(lambda: DeviceAgent, description="DeviceAgent updated by this mutation.")
@@ -69,7 +61,6 @@ class UpdateDeviceAgent(graphene.Mutation):
     def mutate(self, info, input):
         data = graphene_utils.input_to_dictionary(input)
         data['ts_modified'] = datetime.utcnow()
-
         _deviceagent = db_session.query(DeviceAgentModel).filter_by(id=data['id'])
         _deviceagent.update(data)
         db_session.commit()

--- a/infoset/api/schema_deviceagent.py
+++ b/infoset/api/schema_deviceagent.py
@@ -1,0 +1,79 @@
+import graphene
+from graphene import relay
+from graphene_sqlalchemy import SQLAlchemyObjectType, SQLAlchemyConnectionField
+from infoset.api import graphene_utils
+from infoset.db.db_orm import db_session, DeviceAgent as DeviceAgentModel
+from datetime import datetime
+
+class DeviceAgentAttribute:
+    
+
+    idx_deviceagent =  graphene.ID(description="")
+
+    idx_device = graphene.Float(description="")
+    
+    idx_agent = graphene.Float(description="")
+
+    last_timestamp = graphene.Float(description="")
+
+    enabled = graphene.Float(description="")
+
+    ts_modified = graphene.DateTime(description="")
+
+    ts_created = graphene.DateTime(description="")
+
+
+class DeviceAgent(SQLAlchemyObjectType, DeviceAgentAttribute):
+    class Meta:
+        model = DeviceAgentModel
+        interfaces = (relay.Node, )
+
+
+
+
+
+class DeviceAgentInput(graphene.InputObjectType, DeviceAgentAttribute):
+    """Arguments to create DeviceAgent."""
+    pass
+
+
+class CreateDeviceAgent(graphene.Mutation):
+    """Mutation to create a DeviceAgent."""
+    _deviceagent = graphene.Field(
+        lambda: DeviceAgent, description="DeviceAgent created by this mutation.")
+
+    class Arguments:
+        input = DeviceAgentInput(required=True)
+
+    def mutate(self, info, input):
+        data = graphene_utils.input_to_dictionary(input)
+        data['ts_created'] = datetime.utcnow()
+        data['ts_modified'] = datetime.utcnow()
+
+        _deviceagent = DeviceAgentModel(**data)
+        db_session.add(_deviceagent)
+        db_session.commit()
+
+        return CreateDeviceAgent(_deviceagent=_deviceagent)
+
+class UpdateDeviceAgentInput(graphene.InputObjectType, DeviceAgentAttribute):
+
+    _deviceagent = graphene.ID(required=True, description="Unique identifier of the DeviceAgent")
+
+class UpdateDeviceAgent(graphene.Mutation):
+    _deviceagent = graphene.Field(lambda: DeviceAgent, description="DeviceAgent updated by this mutation.")
+
+    class Arguments:
+        input = UpdateDeviceAgentInput(required=True)
+
+    def mutate(self, info, input):
+        data = graphene_utils.input_to_dictionary(input)
+        data['ts_modified'] = datetime.utcnow()
+
+        _deviceagent = db_session.query(DeviceAgentModel).filter_by(id=data['id'])
+        _deviceagent.update(data)
+        db_session.commit()
+        _deviceagent = db_session.query(DeviceAgentModel).filter_by(id=data['id']).first()
+
+        return UpdateDeviceAgent(_deviceagent=_deviceagent)
+


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/PalisadoesFoundation/garnet/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | yes
| Deprecations?            |  no
| Tests Added/Pass?        | no/yes
| Fixed Tickets            | #155.2
| License                  | MIT
| Doc PR                   | no<!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | no

<!-- Describe your changes below in as much detail as possible -->
Adds the GraphQL schema for deviceAgent to Infoset. Tests for each query and mutation were carried out manually through GraphiQL. 