### PR TITLE
Cretaes GraphQL Schema for Datapoint

### DIFF
--- a/infoset/api/schema_datapoint.py
+++ b/infoset/api/schema_datapoint.py
@@ -26,13 +26,7 @@ class Datapoint(SQLAlchemyObjectType, DatapointAttribute):
     class Meta:
         model = DatapointModel
         interfaces = (relay.Node, )
-
-
-class DatapointQuery(graphene.ObjectType):
-    node = relay.Node.Field()
-    datapoint = relay.Node.Field(Datapoint)
-    all_datapoints = SQLAlchemyConnectionField(Datapoint)
-
+        
 
 class DatapointInput(graphene.InputObjectType, DatapointAttribute):
     """Arguments to create datapoint."""
@@ -50,13 +44,12 @@ class CreateDatapoint(graphene.Mutation):
     def mutate(self, info, input):
         data = graphene_utils.input_to_dictionary(input)
         data['ts_created'] = datetime.utcnow()
-        
-
         _datapoint = DatapointModel(**data)
         db_session.add(_datapoint)
         db_session.commit()
 
         return CreateDatapoint(_datapoint=_datapoint)
+    
 
 class UpdateDatapointInput(graphene.InputObjectType, DatapointAttribute):
 
@@ -78,11 +71,3 @@ class UpdateDatapoint(graphene.Mutation):
         _datapoint = db_session.query(DatapointModel).filter_by(id=data['id']).first()
 
         return UpdateDatapoint(_datapoint=_datapoint)
-
-class Mutation(graphene.ObjectType):
-    createDatapoint = CreateDatapoint.Field()
-    updateDatapoint = UpdateDatapoint.Field()
-
-schema = graphene.Schema(query=DatapointQuery, mutation = Mutation)
-
-

--- a/infoset/api/schema_datapoint.py
+++ b/infoset/api/schema_datapoint.py
@@ -1,0 +1,88 @@
+import graphene
+from graphene import relay
+from graphene_sqlalchemy import SQLAlchemyObjectType, SQLAlchemyConnectionField
+from infoset.api import graphene_utils
+from infoset.db.db_orm import db_session, Datapoint as DatapointModel
+from datetime import datetime
+
+class DatapointAttribute:
+    idx_datapoint = graphene.ID(description="")
+    idx_deviceagent = graphene.Float(description="")
+    idx_department = graphene.Float(description="")
+    idx_billcode = graphene.Float(description="")
+    id_datapoint = graphene.Float(description="")
+    agent_label = graphene.Float(description="")
+    agent_source = graphene.Float(description="")
+    enabled = graphene.Float(description="")
+    billable = graphene.Float(description="")
+    timefixed_value = graphene.Float(description="")
+    base_type = graphene.Float(description="")
+    last_timestamp = graphene.Float(description="")
+    ts_modified = graphene.DateTime(description="")
+    ts_created = graphene.DateTime(description="")
+
+
+class Datapoint(SQLAlchemyObjectType, DatapointAttribute):
+    class Meta:
+        model = DatapointModel
+        interfaces = (relay.Node, )
+
+
+class DatapointQuery(graphene.ObjectType):
+    node = relay.Node.Field()
+    datapoint = relay.Node.Field(Datapoint)
+    all_datapoints = SQLAlchemyConnectionField(Datapoint)
+
+
+class DatapointInput(graphene.InputObjectType, DatapointAttribute):
+    """Arguments to create datapoint."""
+    pass
+
+
+class CreateDatapoint(graphene.Mutation):
+    """Mutation to create a datapoint."""
+    _datapoint = graphene.Field(
+        lambda: Datapoint, description="Datapoint created by this mutation.")
+
+    class Arguments:
+        input = DatapointInput(required=True)
+
+    def mutate(self, info, input):
+        data = graphene_utils.input_to_dictionary(input)
+        data['ts_created'] = datetime.utcnow()
+        
+
+        _datapoint = DatapointModel(**data)
+        db_session.add(_datapoint)
+        db_session.commit()
+
+        return CreateDatapoint(_datapoint=_datapoint)
+
+class UpdateDatapointInput(graphene.InputObjectType, DatapointAttribute):
+
+    id = graphene.ID(required=True, description="Unique identifier of the Datapoint")
+
+class UpdateDatapoint(graphene.Mutation):
+    _datapoint = graphene.Field(lambda: Datapoint, description="Datapoint updated by this mutation.")
+
+    class Arguments:
+        input = UpdateDatapointInput(required=True)
+
+    def mutate(self, info, input):
+        data = graphene_utils.input_to_dictionary(input)
+        data['edited'] = datetime.utcnow()
+
+        _datapoint = db_session.query(DatapointModel).filter_by(id=data['id'])
+        _datapoint.update(data)
+        db_session.commit()
+        _datapoint = db_session.query(DatapointModel).filter_by(id=data['id']).first()
+
+        return UpdateDatapoint(_datapoint=_datapoint)
+
+class Mutation(graphene.ObjectType):
+    createDatapoint = CreateDatapoint.Field()
+    updateDatapoint = UpdateDatapoint.Field()
+
+schema = graphene.Schema(query=DatapointQuery, mutation = Mutation)
+
+


### PR DESCRIPTION
<!-- 
Before making a PR please make sure to read our contributing guidelines 
https://github.com/PalisadoesFoundation/garnet/blob/master/CONTRIBUTING.md

For any issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR
-->

| Q                        | A <!--(yes/no) -->
| ------------------------ | ---
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | no
| Minor: New Feature?      | yes
| Deprecations?            |  no
| Tests Added/Pass?        | no/yes
| Fixed Tickets            | #155.6
| License                  | MIT
| Doc PR                   |no <!-- if yes, add `[skip ci]` to your commit message to skip CI builds -->
| Dependency Changes       | no

<!-- Describe your changes below in as much detail as possible -->
Adds the GraphQL Schema for Datapoint to Infoset. Tests for each query and mutation were carried out manually through GraphiQL. 